### PR TITLE
Do not affect global decimal rounding rules

### DIFF
--- a/xlcalculator/xlfunctions/math.py
+++ b/xlcalculator/xlfunctions/math.py
@@ -435,9 +435,9 @@ def RADIANS(
 
 def _round(number, num_digits, _rounding=decimal.ROUND_HALF_UP):
     number = decimal.Decimal(str(number))
-    dc = decimal.getcontext()
-    dc.rounding = _rounding
-    ans = round(number, int(num_digits))
+    with decimal.localcontext() as dc:
+        dc.rounding = _rounding
+        ans = round(number, int(num_digits))
     return float(ans)
 
 


### PR DESCRIPTION
When `ROUNDUP()` or `ROUNDDOWN()` is called, it affects how standard `round()` function behaves outside of xlcalculator. This fixes it by not setting the rounding preference globally, but only during the call to one of `ROUND*()` functions.