### PR TITLE
bump yearfrac to 0.4.8 as previous versions (0.4.4) break with latest setuptools

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ pytz==2020.1              # via pandas
 scipy==1.5.4              # via xlcalculator
 six==1.15.0               # via packaging, pip-tools, python-dateutil
 wcwidth==0.1.9            # via pytest
-yearfrac==0.4.4           # via via xlcalculator
+yearfrac==0.4.8           # via via xlcalculator
 zipp==3.1.0               # via importlib-metadata
 
 


### PR DESCRIPTION
fixes #61 